### PR TITLE
fix: omit packages which have no runnable command

### DIFF
--- a/run.js
+++ b/run.js
@@ -318,7 +318,11 @@ module.exports = (function open_jetbrains_ide(opts, extra_args) {
 
     const appInfo = _.chain(apps) // id startsWith ReSharper
       .filter(function _unsupported_apps(app) {
-        return !app.feedData.id.startsWith('ReSharper');
+        const
+            id = _.get(app, "feedData.id") || "",
+            command = _.get(app, "feedData.package.command");
+        return !id.startsWith('ReSharper') &&
+                !!command;
       })
       .map(function _parse_path_mapper(obj) {
         const x = obj.baseDir;


### PR DESCRIPTION
This seems to apply to systems which have dotPeek installed (or perhaps I have a standalone / odd version of dotPeek, I'm not sure): basically, the run.js tool bails out because it asks `path` to join where the second parameter is undefined -- and this turned out to be the command for dotPeek on my machine, from one of the install locations.

With this patch, I can launch webstorm (for example) as intended. My end-goal is to make named launchers for each of the ides I use (for now, just Rider and WebStorm) so that I can use them from the cli like I can with code: `code .` -- for which `open_jetbrains_ide` already does the heavy lifting, but I'd appreciate (after review) acceptance of this patch and an update to the npm package, when convenient (: